### PR TITLE
Improve UI for MatchTest

### DIFF
--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -13,7 +13,7 @@ public class Config {
     public static final Path DEFAULT_CONFIG_FILE = Paths.get("config.json");
 
     // Config values customizable through config file
-    private String appTitle = "Address App";
+    private String appTitle = "3VIA";
     private Level logLevel = Level.INFO;
     private Path userPrefsFilePath = Paths.get("preferences.json");
 

--- a/src/main/java/seedu/address/logic/parser/MatchTestCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MatchTestCommandParser.java
@@ -1,9 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TOPIC;
-
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.MatchTestCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -14,29 +11,17 @@ import seedu.address.model.topic.Topic;
  */
 public class MatchTestCommandParser implements Parser<MatchTestCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the MatchTestCommand
+     * Parses the given {@code String} of argument in the context of the MatchTestCommand
      * and returns an MatchTestCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     public MatchTestCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TOPIC);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_TOPIC)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (args.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MatchTestCommand.MESSAGE_USAGE));
         }
 
-        Topic tag = ParserUtil.parseTopic(argMultimap.getValue(PREFIX_TOPIC).get());
+        Topic tag = ParserUtil.parseTopic(args);
 
         return new MatchTestCommand(tag);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/model/card/IndexedAnswer.java
+++ b/src/main/java/seedu/address/model/card/IndexedAnswer.java
@@ -1,0 +1,31 @@
+package seedu.address.model.card;
+
+/**
+ * An answer that is identified by an id.
+ */
+public class IndexedAnswer extends Answer {
+    private final int id;
+
+    public IndexedAnswer(Answer answer, int id) {
+        super(answer.value);
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof IndexedAnswer)) {
+            return false;
+        }
+
+        IndexedAnswer o = (IndexedAnswer) other;
+        return id == o.id;
+    }
+}

--- a/src/main/java/seedu/address/model/card/IndexedQuestion.java
+++ b/src/main/java/seedu/address/model/card/IndexedQuestion.java
@@ -1,0 +1,31 @@
+package seedu.address.model.card;
+
+/**
+ * A question that is identified by an id.
+ */
+public class IndexedQuestion extends Question {
+    private final int id;
+
+    public IndexedQuestion(Question question, int id) {
+        super(question.value);
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof IndexedQuestion)) {
+            return false;
+        }
+
+        IndexedQuestion o = (IndexedQuestion) other;
+        return id == o.id;
+    }
+}

--- a/src/main/java/seedu/address/model/test/TriviaResult.java
+++ b/src/main/java/seedu/address/model/test/TriviaResult.java
@@ -28,7 +28,7 @@ public class TriviaResult {
         topic = triviaTest.getTopic();
         attempts = triviaTest.getAttempts();
         testDate = triviaTest.getTestDate();
-        duration = triviaTest.getDuration();
+        duration = triviaTest.getDuration().getValue();
     }
 
     public TriviaResult(TestType testType, Topic topic, Date testDate, double duration,

--- a/src/main/java/seedu/address/model/test/TriviaTest.java
+++ b/src/main/java/seedu/address/model/test/TriviaTest.java
@@ -2,9 +2,9 @@ package seedu.address.model.test;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Timer;
 import java.util.function.Supplier;
 
+import javafx.animation.Timeline;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.collections.ObservableList;
 import seedu.address.model.ReadOnlyTriviaBundle;
@@ -25,7 +25,7 @@ public abstract class TriviaTest {
 
     protected boolean isCompleted;
     protected SimpleDoubleProperty duration;
-    protected Timer timer;
+    protected Timeline timer;
 
     public TriviaTest(Topic topic, ReadOnlyTriviaBundle triviaBundle) {
         this.topic = topic;

--- a/src/main/java/seedu/address/model/test/TriviaTest.java
+++ b/src/main/java/seedu/address/model/test/TriviaTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Timer;
 import java.util.function.Supplier;
 
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.collections.ObservableList;
 import seedu.address.model.ReadOnlyTriviaBundle;
 import seedu.address.model.card.Card;
@@ -23,13 +24,13 @@ public abstract class TriviaTest {
     protected final ObservableList<Card> cards;
 
     protected boolean isCompleted;
-    protected double duration;
+    protected SimpleDoubleProperty duration;
     protected Timer timer;
 
     public TriviaTest(Topic topic, ReadOnlyTriviaBundle triviaBundle) {
         this.topic = topic;
         testDate = new Date();
-        duration = 0;
+        duration = new SimpleDoubleProperty(0);
         isCompleted = false;
         cards = triviaBundle.getListOfCardFilteredByTopic(new TopicIsKeywordPredicate(topic.topicName));
     }
@@ -54,7 +55,7 @@ public abstract class TriviaTest {
         return testDate;
     }
 
-    public double getDuration() {
+    public SimpleDoubleProperty getDuration() {
         return duration;
     }
 

--- a/src/main/java/seedu/address/model/test/matchtest/MatchAttempt.java
+++ b/src/main/java/seedu/address/model/test/matchtest/MatchAttempt.java
@@ -2,30 +2,39 @@ package seedu.address.model.test.matchtest;
 
 import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
+import seedu.address.model.card.IndexedAnswer;
+import seedu.address.model.card.IndexedQuestion;
 import seedu.address.model.test.Attempt;
 
 /**
  * Represent an attempt to answer the question during a test.
  */
 public class MatchAttempt extends Attempt {
-    private final Card cardWithAnswer;
+
+    private IndexedAnswer indexedAnswer;
+
+    private IndexedQuestion indexedQuestion;
 
     /**
      * @param cardWithQuestion Represents the card that is associated to the question.
-     * @param cardWithAnswer Represents the card that is associated to the answer.
+     * @param answer Represents the Answer that is matched to the question.
      */
-    public MatchAttempt(Card cardWithQuestion, Card cardWithAnswer) {
-        super(cardWithQuestion, cardWithAnswer.getAnswer().toString(),
-                checkCorrectness(cardWithQuestion, cardWithAnswer));
-        this.cardWithAnswer = cardWithAnswer;
+    public MatchAttempt(Card cardWithQuestion, IndexedQuestion question, IndexedAnswer answer) {
+        super(cardWithQuestion, answer.value, checkCorrectness(cardWithQuestion, answer));
+        indexedAnswer = answer;
+        indexedQuestion = question;
     }
 
-    public Answer getAnswer() {
-        return cardWithAnswer.getAnswer();
+    public IndexedAnswer getIndexedAnswer() {
+        return indexedAnswer;
     }
 
-    private static boolean checkCorrectness(Card cardWithQuestion, Card cardWithAnswer) {
-        return cardWithQuestion.equals(cardWithAnswer);
+    public IndexedQuestion getIndexedQuestion() {
+        return indexedQuestion;
+    }
+
+    private static boolean checkCorrectness(Card cardWithQuestion, Answer answer) {
+        return cardWithQuestion.getAnswer().equals(answer);
     }
 
     @Override
@@ -42,7 +51,6 @@ public class MatchAttempt extends Attempt {
 
         // state check
         MatchAttempt other = (MatchAttempt) obj;
-        return attemptedCard.equals(other.attemptedCard)
-            && cardWithAnswer.equals(other.cardWithAnswer);
+        return attemptedCard.equals(other.attemptedCard);
     }
 }

--- a/src/main/java/seedu/address/ui/test/matchtest/AnswerListPanel.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/AnswerListPanel.java
@@ -1,6 +1,5 @@
 package seedu.address.ui.test.matchtest;
 
-import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
@@ -14,9 +13,8 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.FlashMatchOutcomeEvent;
-import seedu.address.model.card.Answer;
+import seedu.address.model.card.IndexedAnswer;
 import seedu.address.ui.UiPart;
 
 /**
@@ -26,36 +24,33 @@ public class AnswerListPanel extends UiPart<Region> {
     private static final String FXML = "/test/matchtest/AnswerListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(AnswerListPanel.class);
 
-    private final List<Index> displayIndexes;
-
     @FXML
-    private ListView<Answer> matchTestAnswerListView;
+    private ListView<IndexedAnswer> matchTestAnswerListView;
 
-    public AnswerListPanel(ObservableList<Answer> answerList, List<Index> displayIndexes) {
+    public AnswerListPanel(ObservableList<IndexedAnswer> answerList) {
         super(FXML);
 
-        this.displayIndexes = displayIndexes;
         setConnections(answerList);
         registerAsAnEventHandler(this);
     }
 
-    private void setConnections(ObservableList<Answer> answerList) {
+    private void setConnections(ObservableList<IndexedAnswer> answerList) {
         matchTestAnswerListView.setItems(answerList);
-        matchTestAnswerListView.setCellFactory(listView -> new AnswerListViewCell(displayIndexes));
+        matchTestAnswerListView.setCellFactory(listView -> new AnswerListViewCell());
     }
 
     @Subscribe
     private void handleFlashMatchOutcomeEvent(FlashMatchOutcomeEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         matchTestAnswerListView.setCellFactory(listView ->
-                new AnswerListViewCell(displayIndexes, event.indexOfAnswer, event.isCorrect));
+                new AnswerListViewCell(event.indexOfAnswer, event.isCorrect));
 
         Timer timer = new Timer();
         timer.schedule(new TimerTask() {
             @Override
             public void run() {
                 Platform.runLater(() -> matchTestAnswerListView.setCellFactory(listView ->
-                        new AnswerListViewCell(displayIndexes)));
+                        new AnswerListViewCell()));
             };
         }, UiPart.FLASH_TIME);
     }
@@ -63,13 +58,11 @@ public class AnswerListPanel extends UiPart<Region> {
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Card} using a {@code AnswerView}.
      */
-    class AnswerListViewCell extends ListCell<Answer> {
-        private List<Index> displayIndexes;
+    class AnswerListViewCell extends ListCell<IndexedAnswer> {
         private Integer actualIndexOfAnswer;
         private boolean isCorrect;
 
-        public AnswerListViewCell(List<Index> displayIndexes) {
-            this.displayIndexes = displayIndexes;
+        public AnswerListViewCell() {
             actualIndexOfAnswer = null;
         }
 
@@ -78,14 +71,13 @@ public class AnswerListPanel extends UiPart<Region> {
          * @param actualIndexOfAnswer The targetIndex that is needed to be flashed.
          * @param isCorrect Whether the matching card is correct.
          */
-        public AnswerListViewCell(List<Index> displayIndexes, int actualIndexOfAnswer, boolean isCorrect) {
-            this.displayIndexes = displayIndexes;
+        public AnswerListViewCell(int actualIndexOfAnswer, boolean isCorrect) {
             this.actualIndexOfAnswer = actualIndexOfAnswer;
             this.isCorrect = isCorrect;
         }
 
         @Override
-        protected void updateItem(Answer answer, boolean empty) {
+        protected void updateItem(IndexedAnswer answer, boolean empty) {
             super.updateItem(answer, empty);
 
             if (empty || answer == null) {
@@ -93,10 +85,9 @@ public class AnswerListPanel extends UiPart<Region> {
                 setText(null);
             } else {
                 if (actualIndexOfAnswer == null || actualIndexOfAnswer != getIndex()) {
-                    setGraphic(new AnswerView(answer, displayIndexes.get(getIndex()).getOneBased()).getRoot());
+                    setGraphic(new AnswerView(answer, answer.getId()).getRoot());
                 } else {
-                    setGraphic(new AnswerView(answer, displayIndexes.get(getIndex()).getOneBased(),
-                            isCorrect).getRoot());
+                    setGraphic(new AnswerView(answer, answer.getId(), isCorrect).getRoot());
                 }
             }
         }

--- a/src/main/java/seedu/address/ui/test/matchtest/AnswerView.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/AnswerView.java
@@ -33,6 +33,7 @@ public class AnswerView extends UiPart<Region> {
         this.answer = answer;
         id.setText(displayedIndex + ". ");
         answerText.setText(answer.value);
+        answerText.setWrapText(true);
     }
 
     public AnswerView(Answer answer, int displayedIndex, boolean isCorrect) {
@@ -40,6 +41,7 @@ public class AnswerView extends UiPart<Region> {
         this.answer = answer;
         id.setText(displayedIndex + ". ");
         answerText.setText(answer.value);
+        answerText.setWrapText(true);
         if (isCorrect) {
             this.flashBackgroundColor(answerViewPane, new Color(0, 1, 0, 1));
         } else {

--- a/src/main/java/seedu/address/ui/test/matchtest/MatchAttemptView.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/MatchAttemptView.java
@@ -30,7 +30,7 @@ public class MatchAttemptView extends UiPart<Region> {
         this.attempt = attempt;
 
         id.setText(displayedIndex + ". ");
-        attemptText.setText(attempt.getQuestion() + " ---> " + attempt.getAnswer());
+        attemptText.setText(attempt.getQuestion() + " ---> " + attempt.getIndexedAnswer());
         attemptText.setWrapText(true);
         if (attempt.isCorrect()) {
             correctnessIcon.setImage(getImage("/images/tick_icon.png"));

--- a/src/main/java/seedu/address/ui/test/matchtest/MatchAttemptView.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/MatchAttemptView.java
@@ -31,7 +31,7 @@ public class MatchAttemptView extends UiPart<Region> {
 
         id.setText(displayedIndex + ". ");
         attemptText.setText(attempt.getQuestion() + " ---> " + attempt.getAnswer());
-
+        attemptText.setWrapText(true);
         if (attempt.isCorrect()) {
             correctnessIcon.setImage(getImage("/images/tick_icon.png"));
         } else {

--- a/src/main/java/seedu/address/ui/test/matchtest/MatchTestPage.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/MatchTestPage.java
@@ -3,6 +3,7 @@ package seedu.address.ui.test.matchtest;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.test.matchtest.MatchTest;
@@ -25,14 +26,24 @@ public class MatchTestPage extends TriviaTestPage {
     @FXML
     private StackPane matchTestAnswerListPanelPlaceholder;
 
+    @FXML
+    private Label matchTestTopicText;
+
+    @FXML
+    private Label matchTestDurationText;
+
     public MatchTestPage(MatchTest matchTest) {
         super(FXML);
 
-        questionListPanel = new QuestionListPanel(matchTest.getQuestions());
+        questionListPanel = new QuestionListPanel(matchTest.getQuestions(), matchTest.getDisplayQuestionIndexes());
         matchTestQuestionListPanelPlaceholder.getChildren().add(questionListPanel.getRoot());
 
-        answerListPanel = new AnswerListPanel(matchTest.getAnswers());
+        answerListPanel = new AnswerListPanel(matchTest.getAnswers(), matchTest.getDisplayAnswerIndexes());
         matchTestAnswerListPanelPlaceholder.getChildren().add(answerListPanel.getRoot());
+
+        matchTestTopicText.setText(matchTest.getTopic().topicName);
+        matchTestDurationText.textProperty().bind(matchTest.getDuration().asString());
+
         registerAsAnEventHandler(this);
     }
 }

--- a/src/main/java/seedu/address/ui/test/matchtest/MatchTestPage.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/MatchTestPage.java
@@ -35,10 +35,10 @@ public class MatchTestPage extends TriviaTestPage {
     public MatchTestPage(MatchTest matchTest) {
         super(FXML);
 
-        questionListPanel = new QuestionListPanel(matchTest.getQuestions(), matchTest.getDisplayQuestionIndexes());
+        questionListPanel = new QuestionListPanel(matchTest.getQuestions());
         matchTestQuestionListPanelPlaceholder.getChildren().add(questionListPanel.getRoot());
 
-        answerListPanel = new AnswerListPanel(matchTest.getAnswers(), matchTest.getDisplayAnswerIndexes());
+        answerListPanel = new AnswerListPanel(matchTest.getAnswers());
         matchTestAnswerListPanelPlaceholder.getChildren().add(answerListPanel.getRoot());
 
         matchTestTopicText.setText(matchTest.getTopic().topicName);

--- a/src/main/java/seedu/address/ui/test/matchtest/MatchTestResultPage.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/MatchTestResultPage.java
@@ -43,7 +43,7 @@ public class MatchTestResultPage extends TriviaTestResultPage {
 
         this.matchTest = matchTest;
         testDateText.setText(DateUtil.format(matchTest.getTestDate()));
-        durationText.setText(String.valueOf(matchTest.getDuration()) + "s");
+        durationText.setText(String.valueOf(matchTest.getDuration().getValue()) + "s");
         topicText.setText(matchTest.getTopic().topicName);
         numOfCardsText.setText(String.valueOf(matchTest.getCardsTested().size()));
         numOfAttemptsText.setText(String.valueOf(matchTest.getAttempts().size()) + " Attempts");

--- a/src/main/java/seedu/address/ui/test/matchtest/QuestionListPanel.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/QuestionListPanel.java
@@ -1,6 +1,5 @@
 package seedu.address.ui.test.matchtest;
 
-import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
@@ -14,9 +13,8 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.FlashMatchOutcomeEvent;
-import seedu.address.model.card.Question;
+import seedu.address.model.card.IndexedQuestion;
 import seedu.address.ui.UiPart;
 
 /**
@@ -26,29 +24,25 @@ public class QuestionListPanel extends UiPart<Region> {
     private static final String FXML = "/test/matchtest/QuestionListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(QuestionListPanel.class);
 
-    private final List<Index> displayIndexes;
-
     @FXML
-    private ListView<Question> matchTestQuestionListView;
+    private ListView<IndexedQuestion> matchTestQuestionListView;
 
-    public QuestionListPanel(ObservableList<Question> questionList, List<Index> displayIndexes) {
+    public QuestionListPanel(ObservableList<IndexedQuestion> questionList) {
         super(FXML);
-
-        this.displayIndexes = displayIndexes;
         setConnections(questionList);
         registerAsAnEventHandler(this);
     }
 
-    private void setConnections(ObservableList<Question> questionList) {
+    private void setConnections(ObservableList<IndexedQuestion> questionList) {
         matchTestQuestionListView.setItems(questionList);
-        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell(displayIndexes));
+        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell());
     }
 
     @Subscribe
     private void handleFlashMatchOutcomeEvent(FlashMatchOutcomeEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell(displayIndexes,
-                event.indexOfQuestion, event.isCorrect));
+        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell(event.indexOfQuestion,
+                event.isCorrect));
 
         Timer timer = new Timer();
         timer.schedule(new TimerTask() {
@@ -56,7 +50,7 @@ public class QuestionListPanel extends UiPart<Region> {
             public void run() {
                 Platform.runLater(() ->
                             matchTestQuestionListView.setCellFactory(listView ->
-                                    new QuestionListViewCell(displayIndexes)));
+                                    new QuestionListViewCell()));
             };
         }, UiPart.FLASH_TIME);
     }
@@ -64,14 +58,12 @@ public class QuestionListPanel extends UiPart<Region> {
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Card} using a {@code QuestionView}.
      */
-    class QuestionListViewCell extends ListCell<Question> {
-        private List<Index> displayIndexes;
+    class QuestionListViewCell extends ListCell<IndexedQuestion> {
         private Integer actualIndexOfQuestion;
         private boolean isCorrect;
 
-        public QuestionListViewCell(List<Index> displayIndexes) {
+        public QuestionListViewCell() {
             actualIndexOfQuestion = null;
-            this.displayIndexes = displayIndexes;
         }
 
         /**
@@ -79,14 +71,13 @@ public class QuestionListPanel extends UiPart<Region> {
          * @param actualIndexOfQuestion The targetIndex that is needed to be flashed.
          * @param isCorrect Whether the matching card is correct.
          */
-        public QuestionListViewCell(List<Index> displayIndexes, int actualIndexOfQuestion, boolean isCorrect) {
+        public QuestionListViewCell(int actualIndexOfQuestion, boolean isCorrect) {
             this.actualIndexOfQuestion = actualIndexOfQuestion;
             this.isCorrect = isCorrect;
-            this.displayIndexes = displayIndexes;
         }
 
         @Override
-        protected void updateItem(Question question, boolean empty) {
+        protected void updateItem(IndexedQuestion question, boolean empty) {
             super.updateItem(question, empty);
 
             if (empty || question == null) {
@@ -94,10 +85,9 @@ public class QuestionListPanel extends UiPart<Region> {
                 setText(null);
             } else {
                 if (actualIndexOfQuestion == null || actualIndexOfQuestion != getIndex()) {
-                    setGraphic(new QuestionView(question, displayIndexes.get(getIndex()).getOneBased()).getRoot());
+                    setGraphic(new QuestionView(question, question.getId()).getRoot());
                 } else {
-                    setGraphic(new QuestionView(question, displayIndexes.get(getIndex()).getOneBased(),
-                            isCorrect).getRoot());
+                    setGraphic(new QuestionView(question, question.getId(), isCorrect).getRoot());
                 }
             }
         }

--- a/src/main/java/seedu/address/ui/test/matchtest/QuestionListPanel.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/QuestionListPanel.java
@@ -1,5 +1,6 @@
 package seedu.address.ui.test.matchtest;
 
+import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
@@ -13,6 +14,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.FlashMatchOutcomeEvent;
 import seedu.address.model.card.Question;
 import seedu.address.ui.UiPart;
@@ -24,32 +26,37 @@ public class QuestionListPanel extends UiPart<Region> {
     private static final String FXML = "/test/matchtest/QuestionListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(QuestionListPanel.class);
 
+    private final List<Index> displayIndexes;
+
     @FXML
     private ListView<Question> matchTestQuestionListView;
 
-    public QuestionListPanel(ObservableList<Question> questionList) {
+    public QuestionListPanel(ObservableList<Question> questionList, List<Index> displayIndexes) {
         super(FXML);
+
+        this.displayIndexes = displayIndexes;
         setConnections(questionList);
         registerAsAnEventHandler(this);
     }
 
     private void setConnections(ObservableList<Question> questionList) {
-        this.matchTestQuestionListView.setItems(questionList);
-        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell());
+        matchTestQuestionListView.setItems(questionList);
+        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell(displayIndexes));
     }
 
     @Subscribe
     private void handleFlashMatchOutcomeEvent(FlashMatchOutcomeEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell(event.indexOfQuestion,
-                event.isCorrect));
+        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell(displayIndexes,
+                event.indexOfQuestion, event.isCorrect));
 
         Timer timer = new Timer();
         timer.schedule(new TimerTask() {
             @Override
             public void run() {
                 Platform.runLater(() ->
-                        matchTestQuestionListView.setCellFactory(listView -> new QuestionListViewCell()));
+                            matchTestQuestionListView.setCellFactory(listView ->
+                                    new QuestionListViewCell(displayIndexes)));
             };
         }, UiPart.FLASH_TIME);
     }
@@ -58,21 +65,24 @@ public class QuestionListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Card} using a {@code QuestionView}.
      */
     class QuestionListViewCell extends ListCell<Question> {
-        private Integer indexOfQuestion;
+        private List<Index> displayIndexes;
+        private Integer actualIndexOfQuestion;
         private boolean isCorrect;
 
-        public QuestionListViewCell() {
-            indexOfQuestion = null;
+        public QuestionListViewCell(List<Index> displayIndexes) {
+            actualIndexOfQuestion = null;
+            this.displayIndexes = displayIndexes;
         }
 
         /**
          * Used for defining which cell to flash, with the boolean whether it is correct.
-         * @param indexOfQuestion The targetIndex that is needed to be flashed.
+         * @param actualIndexOfQuestion The targetIndex that is needed to be flashed.
          * @param isCorrect Whether the matching card is correct.
          */
-        public QuestionListViewCell(int indexOfQuestion, boolean isCorrect) {
-            this.indexOfQuestion = indexOfQuestion;
+        public QuestionListViewCell(List<Index> displayIndexes, int actualIndexOfQuestion, boolean isCorrect) {
+            this.actualIndexOfQuestion = actualIndexOfQuestion;
             this.isCorrect = isCorrect;
+            this.displayIndexes = displayIndexes;
         }
 
         @Override
@@ -83,10 +93,11 @@ public class QuestionListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                if (indexOfQuestion == null || indexOfQuestion != getIndex()) {
-                    setGraphic(new QuestionView(question, getIndex() + 1).getRoot());
+                if (actualIndexOfQuestion == null || actualIndexOfQuestion != getIndex()) {
+                    setGraphic(new QuestionView(question, displayIndexes.get(getIndex()).getOneBased()).getRoot());
                 } else {
-                    setGraphic(new QuestionView(question, getIndex() + 1, isCorrect).getRoot());
+                    setGraphic(new QuestionView(question, displayIndexes.get(getIndex()).getOneBased(),
+                            isCorrect).getRoot());
                 }
             }
         }

--- a/src/main/java/seedu/address/ui/test/matchtest/QuestionView.java
+++ b/src/main/java/seedu/address/ui/test/matchtest/QuestionView.java
@@ -28,6 +28,7 @@ public class QuestionView extends UiPart<Region> {
         this.question = question;
         id.setText(displayedIndex + ". ");
         questionText.setText(question.value);
+        questionText.setWrapText(true);
     }
 
     public QuestionView(Question question, int displayedIndex, boolean isCorrect) {
@@ -35,6 +36,7 @@ public class QuestionView extends UiPart<Region> {
         this.question = question;
         id.setText(displayedIndex + ". ");
         questionText.setText(question.value);
+        questionText.setWrapText(true);
         if (isCorrect) {
             this.flashBackgroundColor(questionViewPane, new Color(0, 1, 0, 1));
         } else {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -18,7 +18,7 @@
 }
 
 .label-bright-header {
-    -fx-font-size: 22pt;
+    -fx-font-size: 20pt;
     -fx-font-family: "Segoe UI Semibold";
     -fx-text-fill: white;
     -fx-opacity: 1;
@@ -141,6 +141,10 @@
 
 .stack-pane {
      -fx-background-color: derive(#1d1d1d, 20%);
+}
+
+.hbox {
+    -fx-background-color: derive(#1d1d1d, 20%);
 }
 
 .pane-with-border {

--- a/src/main/resources/view/test/matchtest/AnswerView.fxml
+++ b/src/main/resources/view/test/matchtest/AnswerView.fxml
@@ -14,7 +14,7 @@
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
         </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+        <VBox alignment="CENTER_LEFT" minHeight="60" GridPane.columnIndex="0">
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15" />
             </padding>

--- a/src/main/resources/view/test/matchtest/MatchTestPage.fxml
+++ b/src/main/resources/view/test/matchtest/MatchTestPage.fxml
@@ -20,7 +20,7 @@
                 </HBox>
             </children>
          </StackPane>
-         <Region prefHeight="200.0" prefWidth="200.0" HBox.hgrow="ALWAYS" />
+         <Region prefHeight="200.0" prefWidth="82.25" HBox.hgrow="ALWAYS" />
          <StackPane alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="185.0">
             <children>
                 <HBox alignment="CENTER_LEFT">

--- a/src/main/resources/view/test/matchtest/MatchTestPage.fxml
+++ b/src/main/resources/view/test/matchtest/MatchTestPage.fxml
@@ -1,25 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<?import javafx.scene.control.SplitPane?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.layout.StackPane?>
-
 <VBox xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1">
+   <HBox prefHeight="60.0" prefWidth="690.0" styleClass="hbox">
+      <children>
+         <Region prefHeight="100.0" prefWidth="229.0" HBox.hgrow="ALWAYS" />
+         <StackPane prefHeight="100.0" prefWidth="391.0">
+            <children>
+                <HBox alignment="CENTER">
+                    <Label styleClass="label-bright-header" text="Topic:" />
+                    <Label fx:id="matchTestTopicText" styleClass="label-bright-header" text="\$topicText" />
+                </HBox>
+            </children>
+         </StackPane>
+         <Region prefHeight="200.0" prefWidth="200.0" HBox.hgrow="ALWAYS" />
+         <StackPane alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="185.0">
+            <children>
+                <HBox alignment="CENTER_LEFT">
+                    <Label styleClass="label-bright" text="Duration:" />
+                    <Label fx:id="matchTestDurationText" styleClass="label-bright" text="\$durationText" />
+                </HBox>
+            </children>
+         </StackPane>
+      </children>
+   </HBox>
+
     <SplitPane id="MatchTestSplitPane" fx:id="MatchTestSplitPane" dividerPositions="0.5" VBox.vgrow="ALWAYS">
         <VBox fx:id="MatchTestQuestionListView" minWidth="340" prefWidth="340" SplitPane.resizableWithParent="false">
             <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
+                <Insets bottom="10" left="10" right="10" top="10" />
             </padding>
-            <StackPane fx:id="matchTestQuestionListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            <StackPane fx:id="matchTestQuestionListPanelPlaceholder" VBox.vgrow="ALWAYS" />
         </VBox>
 
         <VBox fx:id="MatchTestAnswerListView" minWidth="340" prefWidth="340" SplitPane.resizableWithParent="false">
             <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
+                <Insets bottom="10" left="10" right="10" top="10" />
             </padding>
-                <StackPane fx:id="matchTestAnswerListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                <StackPane fx:id="matchTestAnswerListPanelPlaceholder" VBox.vgrow="ALWAYS" />
         </VBox>
     </SplitPane>
 </VBox>

--- a/src/main/resources/view/test/matchtest/MatchTestResultPage.fxml
+++ b/src/main/resources/view/test/matchtest/MatchTestResultPage.fxml
@@ -67,10 +67,10 @@
          <RowConstraints />
     </rowConstraints>
      <children>
-         <Label fx:id="numOfAttemptsText" styleClass="label-bright" style="-fx-font-size: 15pt" text="\$numOfAttemptsText" />
+         <Label fx:id="numOfAttemptsText" style="-fx-font-size: 15pt" styleClass="label-bright" text="\$numOfAttemptsText" />
      </children>
   </GridPane>
-  <VBox fx:id="attemptListView" minWidth="340" prefWidth="340" styleClass="grid-pane">
+  <VBox fx:id="attemptListView" minWidth="340" prefWidth="340" styleClass="grid-pane" VBox.vgrow="ALWAYS">
      <padding>
         <Insets bottom="10" left="10" right="10" top="10" />
      </padding>

--- a/src/main/resources/view/test/matchtest/QuestionView.fxml
+++ b/src/main/resources/view/test/matchtest/QuestionView.fxml
@@ -14,7 +14,7 @@
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="60" GridPane.columnIndex="0">
         <padding>
             <Insets top="5" right="5" bottom="5" left="15" />
         </padding>

--- a/src/test/java/seedu/address/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/address/commons/core/ConfigTest.java
@@ -14,7 +14,7 @@ public class ConfigTest {
 
     @Test
     public void toString_defaultObject_stringReturned() {
-        String defaultConfigAsString = "App title : Address App\n"
+        String defaultConfigAsString = "App title : 3VIA\n"
                 + "Current log level : INFO\n"
                 + "Preference file Location : preferences.json";
 

--- a/src/test/java/seedu/address/logic/commands/MatchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MatchCommandTest.java
@@ -17,7 +17,6 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.card.Card;
 import seedu.address.model.test.TriviaResults;
 import seedu.address.model.test.matchtest.MatchTest;
 import seedu.address.model.topic.Topic;
@@ -57,11 +56,16 @@ public class MatchCommandTest {
 
     @Test
     public void execute_matchSuccess() {
+        Index[] expectedEarthIndexes = MatchTestUtil.getIndexes(expectedMatchTest, Q_EARTH_ROUND);
+        Index[] actualEarthIndexes = MatchTestUtil.getIndexes(matchTest, Q_EARTH_ROUND);
+        Index[] expectedForceIndexes = MatchTestUtil.getIndexes(expectedMatchTest, Q_FORCE_FORMULA);
+        Index[] actualForceIndexes = MatchTestUtil.getIndexes(matchTest, Q_FORCE_FORMULA);
+
         // Matching for the first time
-        assertMatchCommandSuccess(Q_EARTH_ROUND);
+        assertMatchCommandSuccess(actualEarthIndexes, expectedEarthIndexes);
 
         // Matching for the second time
-        assertMatchCommandSuccess(Q_FORCE_FORMULA);
+        assertMatchCommandSuccess(actualForceIndexes, expectedForceIndexes);
     }
 
     @Test
@@ -82,12 +86,10 @@ public class MatchCommandTest {
     /**
      * Execute the match command using the card's question and answer to simulate a matching success.
      */
-    private void assertMatchCommandSuccess(Card cardToMatch) {
-        Index[] expectedCorrectIndexes = MatchTestUtil.getIndexes(expectedMatchTest, cardToMatch);
-        expectedModel.matchQuestionAndAnswer(expectedCorrectIndexes[0], expectedCorrectIndexes[1]);
+    private void assertMatchCommandSuccess(Index[] actualIndexes, Index[] expectedIndexes) {
+        expectedModel.matchQuestionAndAnswer(expectedIndexes[0], expectedIndexes[1]);
 
-        Index[] correctIndexes = MatchTestUtil.getIndexes(matchTest, cardToMatch);
-        assertCommandSuccess(new MatchCommand(correctIndexes[0], correctIndexes[1]), model, commandHistory,
+        assertCommandSuccess(new MatchCommand(actualIndexes[0], actualIndexes[1]), model, commandHistory,
                 MatchCommand.MESSAGE_MATCH_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,8 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.TOPIC_DESC_GIT;
-import static seedu.address.logic.commands.CommandTestUtil.TOPIC_DESC_PHYSICS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TOPIC_GIT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TOPIC_PHYSICS;
 import static seedu.address.testutil.ImportFileUtil.getImportCommand;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
@@ -179,9 +178,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_matchTest() throws Exception {
-        assertTrue(parseCommand(MatchTestCommand.COMMAND_WORD + " " + TOPIC_DESC_PHYSICS)
+        assertTrue(parseCommand(MatchTestCommand.COMMAND_WORD + " " + VALID_TOPIC_PHYSICS)
                 instanceof MatchTestCommand);
-        assertTrue(parseCommand(MatchTestCommand.COMMAND_WORD + " " + TOPIC_DESC_GIT)
+        assertTrue(parseCommand(MatchTestCommand.COMMAND_WORD + " " + VALID_TOPIC_GIT)
                 instanceof MatchTestCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/MatchTestCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MatchTestCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.TOPIC_DESC_PHYSICS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TOPIC_PHYSICS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -16,12 +15,12 @@ public class MatchTestCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsMatchTestCommand() {
-        assertParseSuccess(parser, TOPIC_DESC_PHYSICS, new MatchTestCommand(new Topic(VALID_TOPIC_PHYSICS)));
+        assertParseSuccess(parser, VALID_TOPIC_PHYSICS, new MatchTestCommand(new Topic(VALID_TOPIC_PHYSICS)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "-sdds", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 MatchTestCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/model/test/matchtest/MatchAttemptTest.java
+++ b/src/test/java/seedu/address/model/test/matchtest/MatchAttemptTest.java
@@ -2,43 +2,38 @@ package seedu.address.model.test.matchtest;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_EARTH_FLAT;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_GIT_COMMIT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_EARTH_FLAT;
 import static seedu.address.testutil.TypicalCards.Q_FLAT_EARTH;
 import static seedu.address.testutil.TypicalCards.Q_GIT_COMMIT;
+import static seedu.address.testutil.TypicalCards.Q_TALLEST_BUILDING;
 
 import org.junit.Test;
 
+import seedu.address.model.card.Answer;
 import seedu.address.model.card.Card;
-import seedu.address.testutil.CardBuilder;
+import seedu.address.model.card.IndexedAnswer;
+import seedu.address.model.card.IndexedQuestion;
 
 public class MatchAttemptTest {
-
     @Test
     public void testIncorrectAttempt() {
-        // two obviously different cards
-        assertFalse(new MatchAttempt(Q_FLAT_EARTH, Q_GIT_COMMIT).isCorrect());
-
-        // different question but same answer and topic
-        Card editedCard = new CardBuilder(Q_FLAT_EARTH).withQuestion(VALID_QUESTION_GIT_COMMIT).build();
-        assertFalse(new MatchAttempt(Q_FLAT_EARTH, editedCard).isCorrect());
+        // two different answer
+        assertFalse(generateMatchAttempt(Q_FLAT_EARTH, Q_GIT_COMMIT.getAnswer()).isCorrect());
+        assertFalse(generateMatchAttempt(Q_FLAT_EARTH, Q_TALLEST_BUILDING.getAnswer()).isCorrect());
     }
 
     @Test
     public void testCorrectAttempt() {
-        // two obviously same cards
-        assertTrue(new MatchAttempt(Q_FLAT_EARTH, Q_FLAT_EARTH).isCorrect());
-
-        // different answer and topic but same question
-        Card editedCard = new CardBuilder(Q_GIT_COMMIT).withQuestion(VALID_QUESTION_EARTH_FLAT).build();
-        assertTrue(new MatchAttempt(Q_FLAT_EARTH, editedCard).isCorrect());
+        // two same answer
+        assertTrue(generateMatchAttempt(Q_FLAT_EARTH, Q_FLAT_EARTH.getAnswer()).isCorrect());
+        assertTrue(generateMatchAttempt(Q_FLAT_EARTH, new Answer(VALID_ANSWER_EARTH_FLAT)).isCorrect());
     }
 
     @Test
     public void equals() {
-        MatchAttempt matchAttempt = new MatchAttempt(Q_FLAT_EARTH, Q_FLAT_EARTH);
+        MatchAttempt matchAttempt = generateMatchAttempt(Q_FLAT_EARTH, Q_FLAT_EARTH.getAnswer());
         // same values -> returns true
-        MatchAttempt matchAttemptCopy = new MatchAttempt(Q_FLAT_EARTH, Q_FLAT_EARTH);
+        MatchAttempt matchAttemptCopy = generateMatchAttempt(Q_FLAT_EARTH, Q_FLAT_EARTH.getAnswer());
         assertTrue(matchAttempt.equals(matchAttemptCopy));
 
         // same object -> returns true
@@ -51,8 +46,12 @@ public class MatchAttemptTest {
         assertFalse(matchAttempt.equals(5));
 
         // different cards matched being tested -> returns false
-        assertFalse(matchAttempt.equals(new MatchAttempt(Q_GIT_COMMIT, Q_GIT_COMMIT)));
+        assertFalse(matchAttempt.equals(generateMatchAttempt(Q_GIT_COMMIT, Q_GIT_COMMIT.getAnswer())));
 
     }
 
+    private MatchAttempt generateMatchAttempt(Card cardAttempted, Answer answer) {
+        return new MatchAttempt(cardAttempted, new IndexedQuestion(cardAttempted.getQuestion(), 0),
+                new IndexedAnswer(answer, 0));
+    }
 }

--- a/src/test/java/seedu/address/model/test/matchtest/MatchTestTest.java
+++ b/src/test/java/seedu/address/model/test/matchtest/MatchTestTest.java
@@ -93,12 +93,16 @@ public class MatchTestTest {
     @Test
     public void test_responseToCorrectMatchAttempt() {
         // makes sure the cards that are involved in the correct attempts are removed.
-        matchTest.respondToCorrectAttempt(new MatchAttempt(Q_EARTH_ROUND, Q_EARTH_ROUND));
+        matchTest.respondToCorrectAttempt(MatchTestUtil.generateCorrectMatchAttempt(Q_EARTH_ROUND, earthRoundIndexes));
+
         assertEquals(matchTest.getQuestions().size(), 2);
         assertEquals(matchTest.getAnswers().size(), 2);
 
-        matchTest.respondToCorrectAttempt(new MatchAttempt(Q_DENSITY_FORMULA, Q_DENSITY_FORMULA));
-        matchTest.respondToCorrectAttempt(new MatchAttempt(Q_FORCE_FORMULA, Q_FORCE_FORMULA));
+        matchTest.respondToCorrectAttempt(MatchTestUtil.generateCorrectMatchAttempt(Q_DENSITY_FORMULA,
+                densityFormulaIndexes));
+        matchTest.respondToCorrectAttempt(MatchTestUtil.generateCorrectMatchAttempt(Q_FORCE_FORMULA,
+                forceFormulaIndexes));
+
         assertEquals(matchTest.getAnswers().size(), 0);
         assertEquals(matchTest.getQuestions().size(), 0);
     }
@@ -117,10 +121,9 @@ public class MatchTestTest {
     @Test
     public void test_isCompletedFlagTrue() {
         // If there are no more existing unanswered questions, isCompleted flag should be true.
-        matchTest.respondToCorrectAttempt(new MatchAttempt(Q_EARTH_ROUND, Q_EARTH_ROUND));
-        matchTest.respondToCorrectAttempt(new MatchAttempt(Q_FORCE_FORMULA, Q_FORCE_FORMULA));
-
-        densityFormulaIndexes = MatchTestUtil.getIndexes(matchTest, Q_DENSITY_FORMULA);
+        matchTest.respondToCorrectAttempt(MatchTestUtil.generateCorrectMatchAttempt(Q_EARTH_ROUND, earthRoundIndexes));
+        matchTest.respondToCorrectAttempt(MatchTestUtil.generateCorrectMatchAttempt(Q_FORCE_FORMULA,
+                forceFormulaIndexes));
         model.matchQuestionAndAnswer(densityFormulaIndexes[0], densityFormulaIndexes[1]);
         model.stopTriviaTest();
         assertTrue(matchTest.isCompleted());

--- a/src/test/java/seedu/address/testutil/MatchTestUtil.java
+++ b/src/test/java/seedu/address/testutil/MatchTestUtil.java
@@ -2,6 +2,9 @@ package seedu.address.testutil;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.card.Card;
+import seedu.address.model.card.IndexedAnswer;
+import seedu.address.model.card.IndexedQuestion;
+import seedu.address.model.test.matchtest.MatchAttempt;
 import seedu.address.model.test.matchtest.MatchTest;
 
 /**
@@ -20,5 +23,14 @@ public class MatchTestUtil {
                 Index.fromZeroBased(test.getQuestions().indexOf(card.getQuestion())),
                 Index.fromZeroBased(test.getAnswers().indexOf(card.getAnswer()))
         };
+    }
+
+    /**
+     * Will generate a correct MatchAttempt.
+     */
+    public static MatchAttempt generateCorrectMatchAttempt(Card cardToMatch, Index[] correctIndexes) {
+        return new MatchAttempt(cardToMatch,
+                new IndexedQuestion(cardToMatch.getQuestion(), correctIndexes[0].getOneBased()),
+                new IndexedAnswer(cardToMatch.getAnswer(), correctIndexes[1].getOneBased()));
     }
 }


### PR DESCRIPTION
Resolve #89 

1. Display indexes should not change when user matches the cards correctly.
2. Display a timer during a matching test.
3. Remove white space under AttemptList when window is big enough.
4. The questions and answers during a MatchTest should not be truncated.
5. Reduce the size of each ListCell so as to reduce the need for scrolling.
6. Remove the need to specify `t` tag when starting a match test.