### PR TITLE
Edit EditCommand to prevent weird behaviour

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.events.ui.HideCardInfoPanelEvent;
+import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -81,7 +81,8 @@ public class EditCommand extends Command {
         model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
         model.commitTriviaBundle();
 
-        EventsCenter.getInstance().post(new HideCardInfoPanelEvent());
+        Index indexOfEditedCard = Index.fromZeroBased(model.getFilteredCardList().indexOf(editedCard));
+        EventsCenter.getInstance().post(new JumpToListRequestEvent(indexOfEditedCard));
         return new CommandResult(String.format(MESSAGE_EDIT_CARD_SUCCESS, editedCard));
     }
 

--- a/src/main/java/seedu/address/ui/home/CardListPanel.java
+++ b/src/main/java/seedu/address/ui/home/CardListPanel.java
@@ -61,7 +61,8 @@ public class CardListPanel extends UiPart<Region> {
     private void scrollTo(int index) {
         Platform.runLater(() -> {
             cardListView.scrollTo(index);
-            cardListView.getSelectionModel().clearAndSelect(index);
+            cardListView.getSelectionModel().clearSelection();
+            cardListView.getSelectionModel().select(index);
         });
     }
 

--- a/src/test/java/guitests/guihandles/CardInfoPanelHandle.java
+++ b/src/test/java/guitests/guihandles/CardInfoPanelHandle.java
@@ -11,13 +11,19 @@ public class CardInfoPanelHandle extends NodeHandle<Node> {
     public static final String QUESTION_ID = "#cardInfoQuestion";
 
     private Label question;
+    private Node cardInfoNode;
 
     public CardInfoPanelHandle(Node cardInfoNode) {
         super(cardInfoNode);
         question = getChildNode(QUESTION_ID);
+        this.cardInfoNode = cardInfoNode;
     }
 
     public String getQuestion() {
         return question.getText();
+    }
+
+    public boolean isVisible() {
+        return cardInfoNode.isVisible();
     }
 }

--- a/src/test/java/systemtests/AppSystemTest.java
+++ b/src/test/java/systemtests/AppSystemTest.java
@@ -252,6 +252,10 @@ public abstract class AppSystemTest {
         assertEquals(expectedSelectedCardIndex.getZeroBased(), getCardListPanel().getSelectedCardIndex());
     }
 
+    protected void assertCardInfoPanelEmpty() {
+        assertFalse(getInfoPanel().getCardInfoPanel().isVisible());
+    }
+
     /**
      * Asserts that the browser's url and the selected card in the person list panel remain unchanged.
      * @see BrowserPanelHandle#isUrlChanged()

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -112,17 +112,15 @@ public class EditCommandSystemTest extends AppSystemTest {
 
         /* --------------------- Performing edit operation while a card is selected -------------------------- */
 
-        /* Case: selects first card in the card list, edit a card -> edited, card selection remains unchanged but
-         * browser url changes
+        /* Case: selects first card in the card list, edit a card -> edited, card selection changes to the edited card,
+         * and CardInfoPanel changes to display the info of the selected card.
          */
         showAllCards();
         index = INDEX_FIRST_CARD;
         selectCard(index);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_PM_OF_SG
                 + ANSWER_DESC_PM_OF_SG + TOPIC_DESC_GEN_KNOWLEDGE;
-        // this can be misleading: card selection actually remains unchanged but the
-        // browser's url is updated to reflect the new card's question
-        assertCommandSuccess(command, index, Q_PM_OF_SG, index);
+        assertCommandSuccess(command, index, Q_PM_OF_SG);
 
         /* --------------------------------- Performing invalid edit operation -------------------------------------- */
 
@@ -180,28 +178,19 @@ public class EditCommandSystemTest extends AppSystemTest {
     }
 
     /**
-     * Performs the same verification as {@code assertCommandSuccess(String, Index, Card, Index)} except that
-     * the browser url and selected card remain unchanged.
-     * @param toEdit the index of the current model's filtered list
-     * @see EditCommandSystemTest#assertCommandSuccess(String, Index, Card, Index)
-     */
-    private void assertCommandSuccess(String command, Index toEdit, Card editedCard) {
-        assertCommandSuccess(command, toEdit, editedCard, null);
-    }
-
-    /**
      * Performs the same verification as {@code assertCommandSuccess(String, Model, String, Index)} and in addition,<br>
      * 1. Asserts that result display box displays the success message of executing {@code EditCommand}.<br>
      * 2. Asserts that the model related components are updated to reflect the card at index {@code toEdit} being
      * updated to values specified {@code editedCard}.<br>
+     * 3. Asserts that the editCard is selected after the edit and CardInfoPanel is displayed.
      * @param toEdit the index of the current model's filtered list.
      * @see EditCommandSystemTest#assertCommandSuccess(String, Model, String, Index)
      */
-    private void assertCommandSuccess(String command, Index toEdit, Card editedCard,
-            Index expectedSelectedCardIndex) {
+    private void assertCommandSuccess(String command, Index toEdit, Card editedCard) {
         Model expectedModel = getModel();
         expectedModel.updateCard(expectedModel.getFilteredCardList().get(toEdit.getZeroBased()), editedCard);
         expectedModel.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        Index expectedSelectedCardIndex = Index.fromZeroBased(expectedModel.getFilteredCardList().indexOf(editedCard));
 
         assertCommandSuccess(command, expectedModel,
                 String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard), expectedSelectedCardIndex);
@@ -238,7 +227,7 @@ public class EditCommandSystemTest extends AppSystemTest {
         if (expectedSelectedCardIndex != null) {
             assertSelectedCardChanged(expectedSelectedCardIndex);
         } else {
-            assertSelectedCardViewUnchanged();
+            assertCardInfoPanelEmpty();
         }
         assertStatusBarUnchangedExceptSyncStatus();
     }


### PR DESCRIPTION
Steps to reproduce, if you are NOT on this branch:

1. Select any card.
2. Make any changes to using `edit` command to that card.
3. You should observe that all the cards are deselected.
4. Select any card (can be that same card you select in step 1).
5. Make edits to that card you selected in step 4.
6. You should observe that the select card in step 4 did not get unselected.

I think this behavior, which also exist in AddressBook level4 is due to some implementation details related to ObservableList.

Hence to prevent confusing the user, every time a card is edited, the editedCard will be selected and it's `CardInfoPanel` will be displayed.

Let me know if you have any suggestions to make this better or more intuitive!